### PR TITLE
Prepend bootstrap.log into ceremony.log

### DIFF
--- a/persistence.sh
+++ b/persistence.sh
@@ -100,7 +100,7 @@ save_ansible_vars() {
 	# Prepend bootstrap.log into ceremony.log before github commits and copies to volumes
 	x=$(cat ~/bootstrap.log; cat ${LOG_FILE})
 	echo "$x" > ${LOG_FILE}
-	echo "Finished: $(date) >> ${LOG_FILE}
+	echo "Finished: $(date)" >> ${LOG_FILE}
 	## bootstrap.log will already have a Started: timestamp
 	cp ${LOG_FILE} ${ANSIBLE_DIR}/ceremony.log
 	git config --global user.name "ceremony-script"

--- a/persistence.sh
+++ b/persistence.sh
@@ -99,10 +99,9 @@ upsert_file() {
 save_ansible_vars() {
 	# Prepend bootstrap.log into ceremony.log before github commits and copies to volumes
 	x=$(cat ~/bootstrap.log; cat ${LOG_FILE})
-	echo "$x" > ${LOG_FILE}.combined
-	mv ${LOG_FILE} ${LOG_FILE}.orig
-	mv ${LOG_FILE}.combined ${LOG_FILE}
-	
+	echo "$x" > ${LOG_FILE}
+	echo "Finished: $(date) >> ${LOG_FILE}
+	## bootstrap.log will already have a Started: timestamp
 	cp ${LOG_FILE} ${ANSIBLE_DIR}/ceremony.log
 	git config --global user.name "ceremony-script"
 	git config --global user.email "ceremony@email.com"

--- a/persistence.sh
+++ b/persistence.sh
@@ -97,6 +97,12 @@ upsert_file() {
 }
 
 save_ansible_vars() {
+	# Prepend bootstrap.log into ceremony.log before github commits and copies to volumes
+	x=$(cat ~/bootstrap.log; cat ${LOG_FILE})
+	echo "$x" > ${LOG_FILE}.combined
+	mv ${LOG_FILE} ${LOG_FILE}.orig
+	mv ${LOG_FILE}.combined ${LOG_FILE}
+	
 	cp ${LOG_FILE} ${ANSIBLE_DIR}/ceremony.log
 	git config --global user.name "ceremony-script"
 	git config --global user.email "ceremony@email.com"

--- a/persistence.sh
+++ b/persistence.sh
@@ -97,9 +97,9 @@ upsert_file() {
 }
 
 save_ansible_vars() {
-	# Prepend bootstrap.log into ceremony.log before github commits and copies to volumes
-	x=$(cat ~/bootstrap.log; cat ${LOG_FILE})
-	echo "$x" > ${LOG_FILE}
+	# Prepend bootstrap.log into ceremony.log before github commits and before it's copied to volumes/
+	COMBINED=$(cat ~/bootstrap.log; cat ${LOG_FILE})
+	echo "$COMBINED" > ${LOG_FILE}
 	echo "Finished: $(date)" >> ${LOG_FILE}
 	## bootstrap.log will already have a Started: timestamp
 	cp ${LOG_FILE} ${ANSIBLE_DIR}/ceremony.log


### PR DESCRIPTION
get the bootstrap.log into ceremony.log before ceremony is committed back to our ansible repo
Also a "Finished" timestamp is appended to ceremony.log
