### PR TITLE
Append bridge logs to ceremony.log

### DIFF
--- a/bridge_deployer/logging/logging.go
+++ b/bridge_deployer/logging/logging.go
@@ -13,7 +13,7 @@ var once sync.Once
 // Getter for a singleton log.Logger
 func GetInstance() *log.Logger {
 	once.Do(func() {
-		logger = createLogger("../bridge.log")
+		logger = createLogger("../ceremony.log")
 	})
 	return logger
 }


### PR DESCRIPTION
This PR changes the bridge logger to append log statements to the existing `ceremony.log` file.