### PR TITLE
fixed bridge contract address names in aws

### DIFF
--- a/ceremony-scripts/deploy_bridge_contracts.sh
+++ b/ceremony-scripts/deploy_bridge_contracts.sh
@@ -145,6 +145,7 @@ get_deployer_a_private_key() {
     mv bridge_minter_address ${BASE_DIR}/tmp/bridge_minter_address
  }
 
+# todo - remove?
 deploy_bridge_contracts() {
 
     deployer_a_private_key=$(get_deployer_a_private_key)

--- a/persistence.sh
+++ b/persistence.sh
@@ -169,17 +169,17 @@ persist_bridge_keys() {
 	upsert_secret ${BLOCK_FABRIC_AWS_NOTARY_PRIVATE_KEY} $notary_private_key ${AWS_PRIMARY_PROFILE}
 
 	# bridge contract address -> brand AWS secrets and Blockfabric
-	upsert_secret ${BRAND_AWS_BRIDGE_CONTRACT_ADDRESS} $BRIDGE_CONTRACT_ADDRESS ${AWS_PRIMARY_PROFILE}
-	upsert_secret ${BLOCK_FABRIC_AWS_BRIDGE_CONTRACT_ADDRESS} $BRIDGE_CONTRACT_ADDRESS ${AWS_SECONDARY_PROFILE}
+	# upsert_secret ${BRAND_AWS_BRIDGE_CONTRACT_ADDRESS} $BRIDGE_CONTRACT_ADDRESS ${AWS_PRIMARY_PROFILE}
+	# upsert_secret ${BLOCK_FABRIC_AWS_BRIDGE_CONTRACT_ADDRESS} $BRIDGE_CONTRACT_ADDRESS ${AWS_SECONDARY_PROFILE}
 
 	# contract addresses
 	temp_dir=${BASE_DIR}/tmp
-	persist_address_file ${BRIDGE_CONTRACT_ADDRESS} ${temp_dir}/bridge_address ${AWS_PRIMARY_PROFILE}
+	persist_address_file ${BRAND_AWS_BRIDGE_CONTRACT_ADDRESS} ${temp_dir}/bridge_address ${AWS_PRIMARY_PROFILE}
 	persist_address_file ${BRIDGE_MINTER_CONTRACT_ADDRESS} ${temp_dir}/bridge_minter_address ${AWS_PRIMARY_PROFILE}
 	persist_address_file ${TOKEN_CONTRACT_ADDRESS} ${temp_dir}/token_contract_address ${AWS_PRIMARY_PROFILE}
 
 	# secondary contracts
-	persist_address_file ${BRIDGE_CONTRACT_ADDRESS} ${temp_dir}/bridge_address ${AWS_SECONDARY_PROFILE}
+	persist_address_file ${BLOCK_FABRIC_AWS_BRIDGE_CONTRACT_ADDRESS} ${temp_dir}/bridge_address ${AWS_SECONDARY_PROFILE}
 }
 
 inspect() {


### PR DESCRIPTION
This PR correctly adds the bridge contract addresses into the core and block fabric aws accounts.