### PR TITLE
Bump additions and ceremonyenv repo tags to 2.10.3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,9 +5,9 @@
 
 version="2.3.8"
 chain_repo_tag="2.3.2"
-additions_repo_tag="2.10.2"
+additions_repo_tag="2.10.3"
 ansible_repo_tag="main"
-ceremonyenv_repo_tag="2.10.2"
+ceremonyenv_repo_tag="2.10.3"
 ceremony_os_version=$(cat ${HOME}/version | tail -2)
 export network=$1
 export chain=$2


### PR DESCRIPTION
Updated additions and ceremonyenv repository tags to version 2.10.3.